### PR TITLE
Allow easy copy-paste of manual backporting steps

### DIFF
--- a/patchback/event_handlers.py
+++ b/patchback/event_handlers.py
@@ -58,29 +58,29 @@ MANUAL_BACKPORT_GUIDE_MD_TMPL = """
    instructions you'll refer to it by the name `upstream`. If you don't
    have it, here's how you can add it:
    ```console
-   $ git remote add upstream {git_url}
+   git remote add upstream {git_url}
    ```
 3. Ensure you have the latest copy of upstream and prepare a branch
    that will hold the backported code:
    ```console
-   $ git fetch upstream
-   $ git checkout -b {backport_pr_branch} upstream/{target_branch}
+   git fetch upstream
+   git checkout -b {backport_pr_branch} upstream/{target_branch}
    ```
 4. Now, cherry-pick PR #{pr_number} contents into that branch:
    ```console
-   $ git cherry-pick -x {pr_merge_commit}
+   git cherry-pick -x {pr_merge_commit}
    ```
    If it'll yell at you with something like `fatal: Commit {pr_merge_commit} is
    a merge but no -m option was given.`, add `-m 1` as follows intead:
    ```console
-   $ git cherry-pick -m1 -x {pr_merge_commit}
+   git cherry-pick -m1 -x {pr_merge_commit}
    ```
 5. At this point, you'll probably encounter some merge conflicts. You must
    resolve them in to preserve the patch from PR #{pr_number} as close to the
    original as possible.
 6. Push this branch to your fork on GitHub:
    ```console
-   $ git push origin {backport_pr_branch}
+   git push origin {backport_pr_branch}
    ```
 7. Create a PR, ensure that the CI is green. If it's not — update it so that
    the tests and any other checks pass. This is it!


### PR DESCRIPTION
I notice that when manual backport is needed the copy-paste of the command using the "copy" icon will include the leading `$` which is not desired, for a quick run I suggest removing those from the instructions leaving just the bare command.

![Screenshot_2022-08-18_11-55-20](https://user-images.githubusercontent.com/458654/185378852-9646cc4e-dc91-4bde-a9bb-34725fa494a3.png)

Before: `$ git remote add upstream https://github.com/ansible/galaxy_ng.git` -> `zsh: command not found: $`

Now: `git remote add upstream https://github.com/ansible/galaxy_ng.git`