### PR TITLE
Sort version numbers highest to lowest

### DIFF
--- a/patchback/event_handlers.py
+++ b/patchback/event_handlers.py
@@ -243,7 +243,8 @@ async def on_merge_of_labeled_pr(
     """React to labeled pull request merge."""
     repo_config = await get_patchback_config()
     backport_label_len = len(repo_config.backport_label_prefix)
-    labels = [label['name'] for label in pull_request['labels']]
+    # Sort version numbers highest to lowest
+    labels = sorted((label['name'] for label in pull_request['labels']), reverse=True)
     target_branches = [
         f'{repo_config.target_branch_prefix}{label[backport_label_len:]}'
         for label in labels


### PR DESCRIPTION
Minor preference, but I think the bot should produce backports starting with the newest release first.