### PR TITLE
🐛 Don't render `None` as the backport PR body

### DIFF
--- a/patchback/event_handlers.py
+++ b/patchback/event_handlers.py
@@ -435,6 +435,16 @@ async def process_pr_backport_labels(
     )
 
     logger.info('Creating a backport PR...')
+    backport_pr_body = (
+        f'**This is a backport of PR #{pr_number} as '
+        f'merged into {pr_base_ref} '
+        f'({pr_merge_commit}).**'
+    )
+    # NOTE: GitHub sends `null` as the body of pull requests that have no
+    # NOTE: description. Interpolating it unconditionally would render a
+    # NOTE: literal `None` in the backport PR description.
+    if pr_body:
+        backport_pr_body += f'\n\n{pr_body}'
     try:
         pr_resp = await gh_api.post(
             pr_api_url,
@@ -443,9 +453,7 @@ async def process_pr_backport_labels(
                 f'[{target_branch}] {pr_title}',
                 'head': backport_pr_branch,
                 'base': target_branch,
-                'body': f'**This is a backport of PR #{pr_number} as '
-                f'merged into {pr_base_ref} '
-                f'({pr_merge_commit}).**\n\n{pr_body}',
+                'body': backport_pr_body,
                 'maintainer_can_modify': True,
                 'draft': False,
             },


### PR DESCRIPTION
`pull_request['body']` is `null` for PRs submitted without a description, so the f-string interpolated the string `None` into the backport PR description.

Live example from #49: https://github.com/aio-libs/aiohttp/pull/11772 ends with

> \*\*This is a backport of PR #11771 as merged into master (72fadb8f1a56e8bff0fef23ccf02e2067cd87e41).\*\*
>
> None

Now the original description is only appended when there is one. Output is unchanged for PRs that do have a body; the empty-string case also stops emitting a trailing blank block.

Fixes #49.