### PR TITLE
📝 State the license in the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,3 +5,9 @@
 
 Bug reports and pull requests are welcome at
 https://github.com/sanitizers/patchback-github-app.
+
+
+## License
+
+Patchback is distributed under the terms of the
+[GNU General Public License v3.0](LICENSE).


### PR DESCRIPTION
Split out of #57 per review.

The repo ships a GPL-3.0 `LICENSE` file but the readme never mentions it, so the terms aren't visible to anyone reading the project page.

`pre-commit run --files README.md` is clean.