### PR TITLE
📝 Add the banner and badges to the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,23 @@
+[![SWUbanner]][SWUdocs]
+
+[![pre-commit.ci status badge]][pre-commit.ci results page]
+[![GH Sponsors badge]][GH Sponsors URL]
+
+[SWUbanner]:
+https://raw.githubusercontent.com/vshymanskyy/StandWithUkraine/main/banner-direct-single.svg
+[SWUdocs]:
+https://github.com/vshymanskyy/StandWithUkraine/blob/main/docs/README.md
+
+[pre-commit.ci status badge]:
+https://results.pre-commit.ci/badge/github/sanitizers/patchback-github-app/master.svg
+[pre-commit.ci results page]:
+https://results.pre-commit.ci/latest/github/sanitizers/patchback-github-app/master
+
+[GH Sponsors badge]:
+https://img.shields.io/badge/%40webknjaz-transparent?logo=githubsponsors&logoColor=%23EA4AAA&label=Sponsor&color=2a313c
+[GH Sponsors URL]: https://github.com/sponsors/webknjaz
+
+
 # patchback-github-app
 
 


### PR DESCRIPTION
Split out of #57 per review.

The banner and badges from `tox-dev/tox-pre-commit`, minus the tox-dev one. Link definitions are detached and wrapped onto a second line only where the URL would otherwise run long.

The pre-commit.ci badge points at this repo's `master` — it renders green already. All six URLs return 200, and `pre-commit run --files README.md` is clean.